### PR TITLE
Use Go 1.21 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module rsc.io/script
 
-go 1.22
+go 1.21
 
 require golang.org/x/tools v0.14.0


### PR DESCRIPTION
Whilst trying to test this package on an existing project, I noticed the toolchain was 1.22. I was not aware of any reason for this, so thought that using 1.21 might make it easier for people to try it!