### PR TITLE
go.mod: drop to go1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module rsc.io/script
 
-go 1.21
+go 1.19
 
 require golang.org/x/tools v0.14.0


### PR DESCRIPTION
I just saw https://github.com/rsc/script/commit/334f6c18cff37d66fb02d957d28daf992c18fb9f but would you consider supporting the oldest supported version of Go (1.20) as well?

I've tested on the latest Go 1.20:

```console
$ go version
go version go1.20.12 darwin/arm64

$ go test ./...
?       rsc.io/script   [no test files]
ok      rsc.io/script/internal/diff     0.422s
ok      rsc.io/script/scripttest        0.211s
```

I'm a long term very happy user of rogpeppe/go-internal/testscript and am looking to migrate to rsc.io/script (see https://github.com/rogpeppe/go-internal/issues/238). My [popular project](https://github.com/twpayne/chezmoi) needs to support the oldest supported version of Go as some of the platforms it runs on can be slow to upgrade their Go versions. Updating this module would allow me to migrate to rsc.io/script now.

As `go 1.20` is not accepted in `go.mod`, this PR drops the version to `go 1.19`.
