### PR TITLE
State: delete unused field

### DIFF
--- a/state.go
+++ b/state.go
@@ -26,7 +26,6 @@ type State struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
-	file   string
 	log    bytes.Buffer
 
 	workdir string            // initial working directory


### PR DESCRIPTION
The 'file' field is not used anywhere.